### PR TITLE
[DDS-2022] Set response to default (200).

### DIFF
--- a/src/Controller/HealthzController.php
+++ b/src/Controller/HealthzController.php
@@ -68,7 +68,7 @@ class HealthzController extends ControllerBase {
           'sensor_message' => $resultFailure->getMessage(),
         ]);
       }
-      $response = new CacheableJsonResponse($response, 500);
+      $response = new CacheableJsonResponse($response);
     }
     else {
       $response = new CacheableJsonResponse(['message' => 'All sensors OK!']);


### PR DESCRIPTION
https://digital-vic.atlassian.net/browse/DDS-2022

Even though the sensors are returning failures this is not indicative of a server error.

Parsing of the failures will be used to determine follow-on actions.

### Changes
1. returns the [default response code, 200](https://github.com/symfony/symfony/blob/2bbe79ad70d410fb17f69a2197e5a296e3c29fdb/src/Symfony/Component/HttpFoundation/JsonResponse.php#L61)

