### PR TITLE
[DDS-2022] Set response to 503.

### DIFF
--- a/src/Controller/HealthzController.php
+++ b/src/Controller/HealthzController.php
@@ -68,7 +68,7 @@ class HealthzController extends ControllerBase {
           'sensor_message' => $resultFailure->getMessage(),
         ]);
       }
-      $response = new CacheableJsonResponse($response);
+      $response = new CacheableJsonResponse($response, 503);
     }
     else {
       $response = new CacheableJsonResponse(['message' => 'All sensors OK!']);


### PR DESCRIPTION
https://digital-vic.atlassian.net/browse/DDS-2022

### Motivation
To keep with industry conventions the status code returned when there are failed sensors should be in the 5xx range.

I've chosen 503 based on the justifications in these two SO posts
1. https://stackoverflow.com/a/48005358
2. https://stackoverflow.com/questions/25389261/which-http-status-code-should-i-use-for-a-health-check-failure#comment101723013_40424959

### Changes
1. Updates the response from the default, 200, to 503