### PR TITLE
Disable dblog404 monitoring sensor

### DIFF
--- a/bay_monitoring.install
+++ b/bay_monitoring.install
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @file
+ * Install file for bay_monitoring.
+ */
+
+/**
+ * Disable dblog_404 monitoring sensor.
+ */
+function baywatch_update_10000() {
+  $config_storage = \Drupal::service('config.storage.sync');
+
+  if (!\Drupal::moduleHandler()->moduleExists('monitoring')) {
+    return;
+  }
+
+  $config_name = "monitoring.sensor_config.dblog_404";
+  if (!$config_storage->exists($config_name)) {
+    return;
+  }
+
+  // Load and update the config.
+  $config_data = $config_storage->read($config_name);
+  $config_data['status'] = false;
+  $config_storage->write($config_name, $config_data);
+}
+

--- a/bay_monitoring.install
+++ b/bay_monitoring.install
@@ -9,20 +9,13 @@
  * Disable dblog_404 monitoring sensor.
  */
 function bay_monitoring_update_10000() {
-  $config_storage = \Drupal::service('config.storage.sync');
-
-  if (!\Drupal::moduleHandler()->moduleExists('monitoring')) {
-    return;
-  }
-
   $config_name = "monitoring.sensor_config.dblog_404";
-  if (!$config_storage->exists($config_name)) {
-    return;
+
+  // Load active config.
+  $config = \Drupal::configFactory()->getEditable($config_name);
+
+  // If it exists, update it.
+  if ($config) {
+    $config->set('status', FALSE)->save();
   }
-
-  // Load and update the config.
-  $config_data = $config_storage->read($config_name);
-  $config_data['status'] = false;
-  $config_storage->write($config_name, $config_data);
 }
-

--- a/bay_monitoring.install
+++ b/bay_monitoring.install
@@ -8,7 +8,7 @@
 /**
  * Disable dblog_404 monitoring sensor.
  */
-function baywatch_update_10000() {
+function bay_monitoring_update_10000() {
   $config_storage = \Drupal::service('config.storage.sync');
 
   if (!\Drupal::moduleHandler()->moduleExists('monitoring')) {


### PR DESCRIPTION
This has been causing the healthz pingdom monitor to fail persistently since July as the watchdog table doesnt exist in the database.